### PR TITLE
Start naming of devices from f as recommended per AWS

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -71,7 +71,7 @@ func (e *EC2Instance) AttachEnis() {
 func randDriveNamePicker() (string, error) {
 	ctr := 0
 	deviceName := "/dev/xvd"
-	runes := []rune("bcdefghijklmnopqrstuvwxyz")
+	runes := []rune("fghijklmnopqrstuvwxyz")
 	for {
 		if ctr >= len(runes) {
 			return "", fmt.Errorf("Ran out of drive names")


### PR DESCRIPTION
AWS recommends `/dev/xvd[f-p]` for the naming of EBS backed volumes : https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html