### PR TITLE
Fix process for first run on blank devices

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -9,7 +9,7 @@ import (
 )
 
 //AttachEbsVolumes attaches the given map of {'VolumeName':[]EbsVol} with the EC2 client in the provided ec2Instance
-func (e *EC2Instance) AttachEbsVolumes() map[string][]EbsVol {
+func (e *EC2Instance) AttachEbsVolumes() {
 	var deviceName string
 	var err error
 
@@ -45,7 +45,7 @@ func (e *EC2Instance) AttachEbsVolumes() map[string][]EbsVol {
 
 		}
 	}
-	return localVolumes
+	e.Vols = localVolumes
 }
 
 //AttachEnis attaches the given array of Eni Ids with the EC2 client in the provided ec2Instance


### PR DESCRIPTION
There is currently an issue when running the binary for the first time on a new volume that is unmounted. The volume.AttachedName parameter doesn't get through the next run and therefore crashes the run.